### PR TITLE
feat: Improve upon game logic

### DIFF
--- a/src/main/kotlin/hwr/oop/group1/poker/Game.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/Game.kt
@@ -1,143 +1,54 @@
 package hwr.oop.group1.poker
-import hwr.oop.group1.poker.cli.StateSerializable
 
-class Game : StateSerializable {
-    var round = Round()
+class Game {
+    var round: Round? = null
         private set
+
     var players = emptyList<Player>().toMutableList()
         private set
-    private var dealerPosition = -1
-    private var currentPlayerPosition = 0
 
-    companion object {
-        const val SMALL_BLIND = 5
-        const val BIG_BLIND = 10
+    var smallBlindAmount = 10
+        private set
+
+    var bigBlindAmount = 20
+        private set
+
+    // TODO: Increment after a round ended
+    private var dealerPosition: Int = -1;
+
+    fun setSmallBlind(amount: Int) {
+        require(amount > 0) { "Small blind must be greater than 0" }
+        if (bigBlindAmount > 0) {
+            require(amount < bigBlindAmount) { "Small blind must be less than big blind" }
+        }
+        smallBlindAmount = amount
     }
 
-    private fun payBlinds() {
-        val smbIndex = if (players.size == 2) { //smbIndex = SmallBlindIndex
-            dealerPosition
-        } else {
-            (dealerPosition + 1) % players.size
+    fun setBigBlind(amount: Int) {
+        require(amount > 0) { "Big blind must be greater than 0" }
+        if (smallBlindAmount > 0) {
+            require(amount > smallBlindAmount) { "Big blind must be greater than small blind" }
         }
-        val bbIndex = if (players.size == 2) {
-            (dealerPosition + 1) % players.size
-        } else {
-            (dealerPosition + 2) % players.size
-        }
-        bet(players[smbIndex], SMALL_BLIND)
-        bet(players[bbIndex], BIG_BLIND)
-    }
-
-    private fun bet(player: Player, amount: Int) {
-        round.addToPot(player.betMoney(amount))
-        round.setCurrentBet(Math.max(player.currentBet, round.currentBet))
+        bigBlindAmount = amount
+        println("Big blind set to $bigBlindAmount")
     }
 
     fun addPlayer(player: Player) {
+        // TODO: Exception if the current round isn't over
         players += player
     }
 
     fun newRound() {
-        val deck = Deck()
-        nextDealer()
-        players.forEach {it.resetFold()}
-        round = Round()
-        payBlinds()
-        for (player in players) {
-            player.resetFold()
-            repeat(2){
-                player.addCard(deck.draw())
-            }
-        }
-    }
-
-    private fun nextDealer() {
         dealerPosition = (dealerPosition + 1) % players.size
-    }
-
-    fun dealer(): Player {
-        return players[dealerPosition]
-    }
-
-    private fun nextPlayer() {
-        currentPlayerPosition = (currentPlayerPosition + 1) % players.size
-    }
-
-    fun currentPlayer(): Player {
-        return players[currentPlayerPosition]
-    }
-
-    fun doAction(player: Player, action: Action, amount: Int = 0) {
-        if (player != currentPlayer() || player.hasFolded) throw PlayerOutOfTurnException(player)
-        when (action) {
-            Action.CHECK -> check(player)
-            Action.CALL -> call(player)
-            Action.RAISE -> raise(player, amount)
-            Action.FOLD -> fold(player)
+        players.map {
+            it.resetFold()
+            it.resetCurrentBet()
         }
-        nextPlayer()
-    }
-
-    private fun check(player: Player) {
-        if (round.currentBet != player.currentBet) throw CanNotCheckException(player)
-    }
-
-    private fun call(player: Player) {
-        bet(player, round.currentBet - player.currentBet)
-    }
-
-    private fun raise(player: Player, amount: Int) {
-        if (player.money < amount) throw NotEnoughMoneyException(player, amount)
-        if(player.currentBet + amount <= round.currentBet) throw NotEnoughToRaiseException(player, amount)
-        bet(player, amount)
-    }
-
-    private fun fold(player: Player) {
-        player.fold()
-    }
-
-    override fun toState(): Map<String, Any> {
-        return mapOf(
-            "round" to round.toState(),
-            "players" to players.map { it.toState() },
-            "dealerPosition" to dealerPosition,
-            "currentPlayerPosition" to currentPlayerPosition
+        round = Round(
+            players,
+            smallBlindAmount,
+            bigBlindAmount,
+            dealerPosition,
         )
     }
-
-    override fun fromState(state: Map<String, Any>) {
-        dealerPosition = state["dealerPosition"] as Int
-        round = Round().apply { fromState(state["round"] as Map<String, Any>) }
-        players = (state["players"] as List<Map<String, Any>>).map {
-            Player().apply { fromState(it) }
-        }.toMutableList()
-        currentPlayerPosition = state["currentPlayerPosition"] as Int
-    }
 }
-
-class PlayerOutOfTurnException (
-    player: Player
-): RuntimeException(
-    "player $player can not play if not on turn"
-)
-
-class NotEnoughMoneyException (
-    player: Player,
-    amount: Int
-): RuntimeException(
-    "player $player wants to raise $amount but only has ${player.money}"
-)
-
-class CanNotCheckException (
-    player: Player
-): RuntimeException(
-    "player $player can not check"
-)
-
-class NotEnoughToRaiseException (
-    player: Player,
-    amount: Int
-): RuntimeException(
-    "player $player can not raise, because $amount is not enough"
-)

--- a/src/main/kotlin/hwr/oop/group1/poker/Player.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/Player.kt
@@ -1,12 +1,9 @@
 package hwr.oop.group1.poker
-import hwr.oop.group1.poker.cli.StateSerializable
-
-
 
 class Player(
-    var name: String = "",
-    var money: Int = 0
-) : StateSerializable {
+    var name: String,
+    var money: Int,
+) {
     var hand = mutableListOf<Card>()
         private set
     var hasFolded = false
@@ -23,10 +20,14 @@ class Player(
     }
 
     fun betMoney(money: Int): Int {
-        var amount = Math.min(money, this.money)
+        val amount = Math.min(money, this.money)
         this.money -= amount
-        currentBet += amount
+        currentBet = Math.max(currentBet, amount)
         return amount
+    }
+
+    fun resetCurrentBet() {
+        currentBet = 0
     }
 
     fun fold() {
@@ -38,27 +39,12 @@ class Player(
         hasFolded = false
     }
 
-    override fun toState(): Map<String, Any> {
-        return mapOf(
-            "name" to name,
-            "money" to money,
-            "hasFolded" to hasFolded,
-            "hand" to hand.map { it.toState() }
-        )
-    }
-
-    override fun fromState(state: Map<String, Any>) {
-        name = state["name"] as String
-        money = (state["money"] as Number).toInt()
-        hasFolded = state["hasFolded"] as Boolean
-
-        @Suppress("UNCHECKED_CAST")
-        val handState = state["hand"] as? List<Map<String, String>> ?: emptyList()
-
-        hand = handState.map {
-            val rank = CardRank.valueOf(it["rank"]!!)
-            val suit = CardSuit.valueOf(it["suit"]!!)
-            Card(rank, suit)
-        }.toMutableList()
+    /**
+     * Evaluates the player's hand strength using the community cards.
+     * Returns a HandRank object that can be used to compare hands.
+     */
+    fun evaluatePlayerHand(communityCards: List<Card>): HandRank {
+        val allCards = hand + communityCards
+        return evaluateHand(allCards)
     }
 }

--- a/src/main/kotlin/hwr/oop/group1/poker/Round.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/Round.kt
@@ -54,8 +54,8 @@ class Round(
         // Set the currentPlayer to the player after the bigblind
         currentPlayerPosition = (bigBlindPosition + 1) % players.size
 
+        // assign cards to players
         for (player in players) {
-            // assign cards to players
             (0..<2).forEach {
                 _ -> player.addCard(deck.draw())
             }

--- a/src/main/kotlin/hwr/oop/group1/poker/Round.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/Round.kt
@@ -1,53 +1,301 @@
 package hwr.oop.group1.poker
 import hwr.oop.group1.poker.cli.StateSerializable
 
-class Round : StateSerializable {
-    var deck = Deck()
-        private set
+class Round(
+    val players: List<Player>,
+    val smallBlindAmount: Int = 5,
+    val bigBlindAmount: Int = 10,
+    val dealerPosition: Int = 0,
+) : StateSerializable {
     var communityCards = mutableListOf<Card>()
         private set
-    private var revealedCommunityCardCount = 0
+
+    /**
+     * The current stage of the hand:
+     * 0 = Pre-flop (no community cards)
+     * 1 = Flop (3 community cards)
+     * 2 = Turn (4 community cards)
+     * 3 = River (5 community cards)
+     */
     var stage = 0
         private set
+
+    // Blind positions relative to dealer
+    val smallBlindPosition: Int get() = (dealerPosition + 1) % players.size
+    val bigBlindPosition: Int get() = (dealerPosition + 2) % players.size
+
     var pot = 0
         private set
     var currentBet = 0
         private set
 
+    var currentPlayerPosition = 0
+        private set
+    val currentPlayer get() = players[currentPlayerPosition]
+
+    var lastRaisePosition = -1
+        private set
+
+    private var isBettingRoundComplete = false
+
+    var isHandComplete = false
+        private set
+
+    var lastWinnerAnnouncement = ""
+       private set
+
     init {
-        for(i in 1..5) {
-            addCommunityCard(deck.draw())
+        require(players.size >= 2) { "Need at least 2 players to start a hand" }
+        require(dealerPosition <= players.size - 1) { "The dealer position must be a valid player position" }
+        require(bigBlindAmount > smallBlindAmount) { "The small blind has to be smaller than the big blind" }
+        // Reset round state
+        val deck = Deck()
+
+        payBlinds()
+
+        for (player in players) {
+            // assign cards to players
+            (0..<2).forEach {
+                _ -> player.addCard(deck.draw())
+            }
+        }
+
+        (0..<5).forEach {
+            _ -> communityCards += deck.draw()
         }
     }
-    fun addCommunityCard(card: Card) {
-        this.communityCards += card
-    }
 
-    fun nextStage() {
-        stage++
-        if(stage == 1){
-            revealedCommunityCardCount = 3
-        }else if(stage <= 3){
-            revealedCommunityCardCount++
+    fun doAction(action: Action, amount: Int = 0) {
+        if (isHandComplete) throw HandIsCompleteException()
+
+        when (action) {
+            Action.CHECK -> check()
+            Action.CALL -> call()
+            Action.RAISE -> raise(amount)
+            Action.FOLD -> fold()
+        }
+
+        // Move to next active player
+        nextPlayer()
+
+        // Set isHandComplete to make sure no other actions can be triggered
+        isHandComplete = checkIfHandIsComplete()
+
+        if (isBettingRoundComplete) {
+            handleBettingRoundComplete()
+        } else if (isHandComplete) {
+            determineWinner()
+        } else {
+            checkBettingStageComplete()
         }
     }
 
+    private fun nextPlayer() {
+        do {
+            currentPlayerPosition = (currentPlayerPosition + 1) % players.size
+        } while (players[currentPlayerPosition].hasFolded)
+    }
+
+    private fun check() {
+        if (currentBet != currentPlayer.currentBet) throw CanNotCheckException(currentPlayer)
+    }
+
+    private fun call() {
+        placeBet(currentPlayer, currentBet - currentPlayer.currentBet)
+    }
+
+    private fun raise(amount: Int) {
+        if (currentPlayer.money < amount) throw NotEnoughMoneyException(currentPlayer, amount)
+        if(currentPlayer.currentBet + amount <= currentBet) throw NotEnoughToRaiseException(currentPlayer, amount)
+        placeBet(currentPlayer, amount)
+    }
+
+    private fun fold() {
+        currentPlayer.fold()
+    }
+
+    /**
+     * Returns the community cards that should be visible at the current stage.
+     * - Pre-flop: No cards
+     * - Flop: First 3 cards
+     * - Turn: First 4 cards
+     * - River: All 5 cards
+     */
     fun getRevealedCommunityCards(): List<Card> {
-        return this.communityCards.take(revealedCommunityCardCount)
+        return when (stage) {
+            0 -> emptyList()
+            1 -> communityCards.take(3)
+            2 -> communityCards.take(4)
+            3 -> communityCards
+            else -> emptyList()
+        }
     }
 
-    fun addToPot(money: Int) {
+    /**
+     * Advances to the next stage of the hand.
+     * This is called when a betting round is complete.
+     * Stages progress: Pre-flop -> Flop -> Turn -> River
+     */
+    private fun nextStage() {
+        require(stage < 3) { "Cannot advance past the river" }
+
+        lastRaisePosition = -1
+        currentBet = 0  // Reset current bet for next round
+        players.map { it.resetCurrentBet() }
+        stage++
+    }
+
+    private fun addToPot(money: Int) {
+        require(money >= 0) { "Cannot add negative amount to pot" }
         pot += money
     }
 
-    fun setCurrentBet(bet: Int) {
-        currentBet = bet
+    /**
+     * Places a bet in the current betting round.
+     * Handles calls (matching current bet) and raises (increasing current bet).
+     * Automatically advances to the next player after the bet is placed.
+     */
+    private fun placeBet(player: Player, amount: Int) {
+//        require(isGameStarted) { "Game must be started before placing bets" }
+        require(!isHandComplete) { "Hand is already complete" }
+        require(amount >= 0) { "Bet amount must be non-negative" }
+
+        require(player.money >= amount) { "Player does not have enough money" }
+
+        // Check if the player raised
+        if (amount > currentBet) {
+            lastRaisePosition = currentPlayerPosition
+            currentBet = amount
+        }
+
+        player.betMoney(amount)
+        addToPot(amount)
+    }
+
+    private fun payBlinds() {
+        placeBet(players[smallBlindPosition], smallBlindAmount)
+        placeBet(players[bigBlindPosition], bigBlindAmount)
+        isBettingRoundComplete = false
+        lastRaisePosition = bigBlindPosition
+    }
+
+    /**
+     * Advances to the next player in the betting round.
+     * If all players have acted after the last raise, moves to the next betting round.
+     */
+//    private fun moveToNextPlayer() {
+//        currentPlayerPosition = (currentPlayerPosition + 1) % players.size
+//
+//        // Check if betting round is complete
+//        if (currentPlayerPosition == lastRaisePosition) {
+//            // All players have acted after the last raise
+
+//        }
+//    }
+
+    /**
+     * Checks if the current betting round is complete.
+     * A betting round is complete when:
+     * 1. All players have acted after the last raise
+     * 2. All active players have matched the current bet
+     */
+    private fun checkBettingStageComplete() {
+        if (lastRaisePosition == -1) {
+            // No raises in this round, check if everyone has acted
+            if (currentPlayerPosition == bigBlindPosition) {
+                isBettingRoundComplete = true
+            }
+        } else if (currentPlayerPosition == lastRaisePosition) {
+            // All players have acted after the last raise
+            isBettingRoundComplete = true
+        }
+    }
+
+    /**
+     * Handles the completion of a betting round and progression to the next stage.
+     * If all stages are complete, triggers the showdown.
+     */
+    private fun handleBettingRoundComplete() {
+        if (!isBettingRoundComplete) return
+
+        isBettingRoundComplete = false
+        currentBet = 0
+        lastRaisePosition = -1
+        currentPlayerPosition = (dealerPosition + 1) % players.size
+
+        if (stage < 3) {
+            // Move to next stage
+            nextStage()
+        } else {
+            // River is complete, trigger showdown
+            isHandComplete = true
+            determineWinner()
+        }
+    }
+
+    private fun checkIfHandIsComplete(): Boolean {
+        // Check if only one player is active
+        if (players.filter { !it.hasFolded }.size == 1) return true
+
+        // Check if all players are all in
+        if (players.filter { !it.hasFolded }.all { it.money == 0 }) return true
+
+        return false
+    }
+
+    /**
+     * Determines the winner(s) of the hand and awards the pot.
+     * This is called after the river betting round is complete.
+     * Handles split pots when multiple players have equal hand strength.
+     */
+    private fun determineWinner() {
+        val activePlayers = players.filter { !it.hasFolded }
+        if (activePlayers.size == 1) {
+            // Only one player left, they win
+            val winner = activePlayers[0]
+            winner.addMoney(pot)
+            lastWinnerAnnouncement = "${winner.name} wins $pot chips!"
+            pot = 0
+        } else {
+            // Evaluate hands and find winners
+            val playerHands = activePlayers.map { player ->
+                player to player.evaluatePlayerHand(getRevealedCommunityCards())
+            }
+
+            // Group players by hand strength
+            val groupedByHand = playerHands.groupBy { it.second }
+            val bestHand = groupedByHand.keys.maxOrNull()
+
+            if (bestHand != null) {
+                val winners = groupedByHand[bestHand]!!.map { it.first }
+                val splitAmount = pot / winners.size
+                val remainder = pot % winners.size
+
+                // Award split pot
+                winners.forEach { winner ->
+                    winner.addMoney(splitAmount)
+                }
+
+                // Award remainder to first winner (or could be distributed randomly)
+                if (remainder > 0) {
+                    winners[0].addMoney(remainder)
+                }
+
+                // Create winner announcement
+                lastWinnerAnnouncement = if (winners.size == 1) {
+                    "${winners[0].name} wins $pot chips with ${bestHand.type}!"
+                } else {
+                    val winnerNames = winners.joinToString(", ") { it.name }
+                    "$winnerNames split the pot of $pot chips (${splitAmount} each) with ${bestHand.type}!"
+                }
+                pot = 0
+            }
+        }
     }
 
     override fun toState(): Map<String, Any> {
         return mapOf(
             "communityCards" to communityCards.map { it.toState() },
-            "revealedCommunityCardCount" to revealedCommunityCardCount,
             "stage" to stage,
             "pot" to pot
         )
@@ -56,8 +304,31 @@ class Round : StateSerializable {
         communityCards = (state["communityCards"] as List<Map<String, Any>>).map {
             Card(CardRank.valueOf(it["rank"] as String), CardSuit.valueOf(it["suit"] as String))
         }.toMutableList()
-        revealedCommunityCardCount = (state["revealedCommunityCardCount"] as Number).toInt()
         stage = (state["stage"] as Number).toInt()
         pot = (state["pot"] as Number).toInt()
     }
 }
+
+class NotEnoughMoneyException (
+    player: Player,
+    amount: Int
+): RuntimeException(
+    "player $player wants to raise $amount but only has ${player.money}"
+)
+
+class CanNotCheckException (
+    player: Player
+): RuntimeException(
+    "player $player can not check"
+)
+
+class NotEnoughToRaiseException (
+    player: Player,
+    amount: Int
+): RuntimeException(
+    "player $player can not raise, because $amount is not enough"
+)
+
+class HandIsCompleteException: RuntimeException(
+    "The Hand is already complete, to play again start a new round."
+)

--- a/src/main/kotlin/hwr/oop/group1/poker/Round.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/Round.kt
@@ -56,13 +56,13 @@ class Round(
 
         // assign cards to players
         for (player in players) {
-            (0..<2).forEach {
-                _ -> player.addCard(deck.draw())
+            repeat(2) {
+                player.addCard(deck.draw())
             }
         }
 
-        (0..<5).forEach {
-            _ -> communityCards += deck.draw()
+        repeat(5) {
+            communityCards += deck.draw()
         }
     }
 

--- a/src/main/kotlin/hwr/oop/group1/poker/cli/GameStateManager.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/cli/GameStateManager.kt
@@ -38,7 +38,7 @@ class JsonStateManager(private val file: File = File("poker_state.json")) : Stat
 class GameStateManager(private val stateManager: StateManager = JsonStateManager()) {
     // game → map → save
     fun saveState(game: Game) {
-        stateManager.saveState(game.toState())
+//        stateManager.saveState(game.toState())
     }
 
     fun loadState(): Game? {
@@ -46,7 +46,7 @@ class GameStateManager(private val stateManager: StateManager = JsonStateManager
 
         return try {
             val game = Game()
-            game.fromState(state) // map → game
+//            game.fromState(state) // map → game
             game
         } catch (e: Exception) {
             println("Error loading game state: ${e.message}")

--- a/src/test/kotlin/hwr/oop/group1/poker/GameStateManagerTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/GameStateManagerTest.kt
@@ -41,7 +41,7 @@ class GameStateManagerTest {
         assertThat(loadedGame.players[1].money).isEqualTo(expectedMoney2)
 
         // pot correct?
-        assertThat(loadedGame.round.pot).isEqualTo(originalGame.round.pot)
+        assertThat(loadedGame.round!!.pot).isEqualTo(originalGame.round!!.pot)
 
         tempFile.delete() // delete temporary file
     }

--- a/src/test/kotlin/hwr/oop/group1/poker/GameTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/GameTest.kt
@@ -9,7 +9,7 @@ class GameTest: AnnotationSpec() {
     @Test
     fun `Game has added Player`() {
         val game = Game()
-        val player = Player("Max")
+        val player = Player("Max", 1000)
 
         game.addPlayer(player)
         val players = game.players
@@ -18,249 +18,45 @@ class GameTest: AnnotationSpec() {
     }
 
     @Test
-    fun `Dealer is first player after new Round`() {
+    fun `Game starts Round`() {
         val game = Game()
-        val player1 = Player("Max")
-        val player2 = Player("Ben")
+        val player1 = Player("Max", 1000)
+        val player2 = Player("Max", 1000)
+
         game.addPlayer(player1)
         game.addPlayer(player2)
-
         game.newRound()
-        val dealer = game.dealer()
 
-        assertThat(dealer).isEqualTo(player1)
+        assertThat(game.round?.players).contains(player1)
+        assertThat(game.round?.players).contains(player2)
+        assertThat(game.round?.smallBlindAmount).isEqualTo(game.smallBlindAmount)
+        assertThat(game.round?.bigBlindAmount).isEqualTo(game.bigBlindAmount)
     }
 
     @Test
-    fun `small and big blinds are paid (for more than 2 players)`() {
+    fun `Set small and big blind sets it correctly`() {
         val game = Game()
-        val a = Player("Harry", money = 100)
-        val b = Player("Ron", money = 100)
-        val c = Player("Hermione", money = 100)
-        game.addPlayer(a)
-        game.addPlayer(b)
-        game.addPlayer(c)
 
+        game.setBigBlind(40)
+        game.setSmallBlind(20)
 
-        game.newRound()
-
-        assertThat(b.money).isEqualTo(100 - Game.SMALL_BLIND)
-        assertThat(c.money).isEqualTo(100 - Game.BIG_BLIND)
-        assertThat(game.round.pot).isEqualTo(Game.SMALL_BLIND + Game.BIG_BLIND)
-
-        assertThat(a.money).isEqualTo(100)
-    }
-
-    @Test
-    fun `dealer pays small blind and other pays big blind in heads up (2 players)`() {
-
-        val game = Game()
-        val first  = Player("Harry",  money = 200)
-        val second = Player("Ron", money = 200)
-        game.addPlayer(first)
-        game.addPlayer(second)
-
-        game.newRound()
-
-        assertThat(first.money).isEqualTo(200 - Game.SMALL_BLIND)
-        assertThat(second.money).isEqualTo(200 - Game.BIG_BLIND)
-        assertThat(game.round.pot).isEqualTo(Game.SMALL_BLIND + Game.BIG_BLIND)
-    }
-
-    @Test
-    fun `players are dealt two cards at the beginning of a new round`() {
-        val game = Game()
-        val alice  = Player("Alice",  money = 100)
-        val bob = Player("Bob", money = 100)
-        game.addPlayer(alice)
-        game.addPlayer(bob)
-
-        game.newRound()
-
-        assertThat(alice.hand.size).isEqualTo(2)
-    }
-
-    @Test
-    fun `players can not do an action if it is not their turn`(){
-        val game = Game()
-        val alice  = Player("Alice",  money = 100)
-        val bob = Player("Bob", money = 100)
-        val max = Player("Max", money = 100)
-        game.addPlayer(alice)
-        game.addPlayer(bob)
-        game.addPlayer(max)
-
-        game.newRound()
-        assertThatThrownBy {
-            game.doAction(bob, Action.CHECK)
-        }.hasMessageContainingAll(
-            bob.toString(),
-            "can not play if not on turn"
-        )
-        assertThatThrownBy {
-            game.doAction(bob, Action.CALL)
-        }.hasMessageContainingAll(
-            bob.toString(),
-            "can not play if not on turn"
-        )
-        assertThatThrownBy {
-            game.doAction(bob, Action.RAISE)
-        }.hasMessageContainingAll(
-            bob.toString(),
-            "can not play if not on turn"
-        )
-        assertThatThrownBy {
-            game.doAction(bob, Action.FOLD)
-        }.hasMessageContainingAll(
-            bob.toString(),
-            "can not play if not on turn"
-        )
-    }
-
-    @Test
-    fun `players can call`(){
-        val game = Game()
-        val alice  = Player("Alice",  money = 100)
-        val bob = Player("Bob", money = 100)
-        val max = Player("Max", money = 100)
-        game.addPlayer(alice)
-        game.addPlayer(bob)
-        game.addPlayer(max)
-
-        game.newRound()
-        val potBefore = game.round.pot
-        game.doAction(alice, Action.CALL)
-
-        assertThat(alice.money).isEqualTo(100 - Game.BIG_BLIND)
-        assertThat(game.round.pot).isEqualTo(potBefore + Game.BIG_BLIND)
-        assertThat(game.currentPlayer()).isEqualTo(bob)
-    }
-
-    @Test
-    fun `players can check`(){
-        val game = Game()
-        val alice  = Player("Alice",  money = 100)
-        val bob = Player("Bob", money = 100)
-        val max = Player("Max", money = 100)
-        game.addPlayer(alice)
-        game.addPlayer(bob)
-        game.addPlayer(max)
-
-        game.newRound()
-        game.doAction(alice, Action.CALL)
-        game.doAction(bob, Action.CALL)
-
-        val potBefore = game.round.pot
-        val moneyBefore = max.money
-        game.doAction(max, Action.CHECK)
-
-        assertThat(max.money).isEqualTo(moneyBefore)
-        assertThat(game.round.pot).isEqualTo(potBefore)
-        assertThat(game.currentPlayer()).isEqualTo(alice)
-    }
-
-    @Test
-    fun `players can not check in first round`(){
-        val game = Game()
-        val alice  = Player("Alice",  money = 100)
-        val bob = Player("Bob", money = 100)
-        val max = Player("Max", money = 100)
-        game.addPlayer(alice)
-        game.addPlayer(bob)
-        game.addPlayer(max)
-
-        game.newRound()
-        assertThatThrownBy {
-            game.doAction(alice, Action.CHECK)
-        }.hasMessageContainingAll(
-            alice.toString(),
-            "can not check"
-        )
-    }
-
-    @Test
-    fun `players can raise`(){
-        val game = Game()
-        val alice  = Player("Alice",  money = 100)
-        val bob = Player("Bob", money = 100)
-        val max = Player("Max", money = 100)
-        game.addPlayer(alice)
-        game.addPlayer(bob)
-        game.addPlayer(max)
-
-        game.newRound()
-        game.doAction(alice, Action.CALL)
-        game.doAction(bob, Action.CALL)
-
-        val currentBetBefore = game.round.currentBet
-        val potBefore = game.round.pot
-        val moneyBefore = max.money
-        game.doAction(max, Action.RAISE, 30)
-
-        assertThat(max.money).isEqualTo(moneyBefore - 30)
-        assertThat(game.round.pot).isEqualTo(potBefore + 30)
-        assertThat(game.round.currentBet).isEqualTo(currentBetBefore + 30)
-        assertThat(game.currentPlayer()).isEqualTo(alice)
-    }
-
-    @Test
-    fun `players can not raise more than they have`(){
-        val game = Game()
-        val alice  = Player("Alice",  money = 100)
-        val bob = Player("Bob", money = 100)
-        val max = Player("Max", money = 100)
-        game.addPlayer(alice)
-        game.addPlayer(bob)
-        game.addPlayer(max)
-
-        game.newRound()
-        game.doAction(alice, Action.CALL)
-        game.doAction(bob, Action.CALL)
+        assertThat(game.smallBlindAmount).isEqualTo(20)
+        assertThat(game.bigBlindAmount).isEqualTo(40)
 
         assertThatThrownBy {
-            game.doAction(max, Action.RAISE, 100)
-        }.hasMessageContainingAll(
-            max.toString(),
-            "wants to raise 100",
-            "only has " + max.money
-        )
-    }
-
-    @Test
-    fun `players can not raise to less than the current bet`(){
-        val game = Game()
-        val alice  = Player("Alice",  money = 100)
-        val bob = Player("Bob", money = 100)
-        val max = Player("Max", money = 100)
-        game.addPlayer(alice)
-        game.addPlayer(bob)
-        game.addPlayer(max)
-
-        game.newRound()
+            game.setBigBlind(10)
+        }.hasMessageContaining("Big blind must be greater than small blind")
 
         assertThatThrownBy {
-            game.doAction(alice, Action.RAISE, 5)
-        }.hasMessageContainingAll(
-            alice.toString(),
-            "can not raise",
-            "5 is not enough"
-        )
-    }
+            game.setSmallBlind(50)
+        }.hasMessageContaining("Small blind must be less than big blind")
 
-    @Test
-    fun `players can fold`(){
-        val game = Game()
-        val alice  = Player("Alice",  money = 100)
-        val bob = Player("Bob", money = 100)
-        val max = Player("Max", money = 100)
-        game.addPlayer(alice)
-        game.addPlayer(bob)
-        game.addPlayer(max)
+        assertThatThrownBy {
+            game.setBigBlind(0)
+        }.hasMessageContaining("Big blind must be greater than 0")
 
-        game.newRound()
-        game.doAction(alice, Action.FOLD)
-
-        assertThat(alice.hasFolded).isTrue()
-        assertThat(game.currentPlayer()).isEqualTo(bob)
+        assertThatThrownBy {
+            game.setSmallBlind(0)
+        }.hasMessageContaining("Small blind must be greater than 0")
     }
 }

--- a/src/test/kotlin/hwr/oop/group1/poker/PlayerTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/PlayerTest.kt
@@ -7,7 +7,7 @@ class PlayerTest: AnnotationSpec() {
 
     @Test
     fun `Player Max has name Max`() {
-        val player = Player("Max")
+        val player = Player("Max", 1000)
 
         val name = player.name
 
@@ -16,7 +16,7 @@ class PlayerTest: AnnotationSpec() {
 
     @Test
     fun `Player has added Card`() {
-        val player = Player("Max")
+        val player = Player("Max", 1000)
         val card = Card(CardRank.FIVE, CardSuit.SPADES)
 
         player.addCard(card)
@@ -26,17 +26,17 @@ class PlayerTest: AnnotationSpec() {
 
     @Test
     fun `Player Money is 10 after adding 10`() {
-        val player = Player("Max")
+        val player = Player("Max", 1000)
 
         player.addMoney(10)
         val playerMoney = player.money
 
-        assertThat(playerMoney).isEqualTo(10)
+        assertThat(playerMoney).isEqualTo(1010)
     }
     @Test
     fun `fold sets hasFolded to true `() {
 
-        val player = Player("Saruman", money = 50)
+        val player = Player("Saruman", 50)
         assertThat(player.hasFolded).isFalse()  // vorab
 
 
@@ -48,7 +48,7 @@ class PlayerTest: AnnotationSpec() {
 
     @Test 
     fun `fold clears hand`() {
-        val player = Player("Saruman", money = 50)
+        val player = Player("Saruman", 50)
         player.addCard(Card(CardRank.ACE, CardSuit.SPADES))
         player.addCard(Card(CardRank.KING, CardSuit.HEARTS))
         player.fold()
@@ -58,37 +58,13 @@ class PlayerTest: AnnotationSpec() {
 
     @Test
     fun `resetFold clears fold status`() {
-
-        val player = Player("Saruman", money = 50)
+        val player = Player("Saruman", 50)
         player.addCard(Card(CardRank.ACE, CardSuit.SPADES))
         player.addCard(Card(CardRank.KING, CardSuit.HEARTS))
         player.fold()
         assertThat(player.hasFolded).isTrue()
         player.resetFold()
         assertThat(player.hasFolded).isFalse()
-    }
-
-    @Test
-    fun `player state is correctly converted and restored`() {
-        val original = Player(name = "Voldemort", money = 300)
-        original.addCard(Card(CardRank.ACE, CardSuit.SPADES))
-        original.addCard(Card(CardRank.TEN, CardSuit.HEARTS))
-        original.fold() // player fold → hasFolded = true, clear hand
-
-        val state = original.toState() // serialize player in map
-
-        val copy = Player()
-        copy.fromState(state)
-
-
-        assertThat(copy.name).isEqualTo("Voldemort")
-        assertThat(copy.money).isEqualTo(300)
-
-
-        assertThat(copy.hasFolded).isTrue()
-
-
-        assertThat(copy.hand).isEmpty()
     }
 }
 

--- a/src/test/kotlin/hwr/oop/group1/poker/RoundTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/RoundTest.kt
@@ -161,17 +161,4 @@ class RoundTest : AnnotationSpec() {
         val totalMoney = players.sumOf { it.money }
         assertThat(totalMoney).isEqualTo(3000)
     }
-
-    @Test
-    fun `toState and fromState preserve state`() {
-        val state = round.toState()
-
-        val restoredRound = Round(players)
-        restoredRound.fromState(state)
-
-        assertThat(restoredRound.stage).isEqualTo(round.stage)
-        assertThat(restoredRound.pot).isEqualTo(round.pot)
-        assertThat(restoredRound.getRevealedCommunityCards())
-            .containsExactlyElementsOf(round.getRevealedCommunityCards())
-    }
 }

--- a/src/test/kotlin/hwr/oop/group1/poker/RoundTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/RoundTest.kt
@@ -2,90 +2,176 @@ package hwr.oop.group1.poker
 
 import io.kotest.core.spec.style.AnnotationSpec
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 
-class RoundTest: AnnotationSpec() {
+class RoundTest : AnnotationSpec() {
+    lateinit var round: Round
+    lateinit var players: List<Player>
+
+    @BeforeEach
+    fun setUp() {
+        players = listOf(
+            Player("Alice", 1000),
+            Player("Bob", 1000),
+            Player("Caroline", 1000)
+        )
+        round = Round(players, 5, 10)
+    }
 
     @Test
     fun `stage is 0 at start`() {
-        val round = Round()
-
-        val stage = round.stage
-
-        assertThat(stage).isEqualTo(0)
+        assertThat(round.stage).isEqualTo(0)
     }
 
     @Test
-    fun `stage is 1 after next Stage`() {
-        val round = Round()
-
-        round.nextStage()
-        val stage = round.stage
-
-        assertThat(stage).isEqualTo(1)
+    fun `blinds are paid on round init`() {
+        assertThat(round.pot).isEqualTo(15)
+        assertThat(players[1].money).isEqualTo(995) // small blind
+        assertThat(players[2].money).isEqualTo(990) // big blind
     }
 
     @Test
-    fun `There are 5 community cards at the start`() {
-        val round = Round()
-        assertThat(round.communityCards.size).isEqualTo(5)
+    fun `currentPlayer is player after big blind`() {
+        assertThat(round.currentPlayer.name).isEqualTo("Alice")
     }
 
     @Test
-    fun `correct amount of revealed community cards in stages`() {
-        val round = Round()
-
-        assertThat(round.getRevealedCommunityCards().size).isEqualTo(0)
-
-        round.nextStage()
-        assertThat(round.getRevealedCommunityCards().size).isEqualTo(3)
-
-        round.nextStage()
-        assertThat(round.getRevealedCommunityCards().size).isEqualTo(4)
-
-        round.nextStage()
-        assertThat(round.getRevealedCommunityCards().size).isEqualTo(5)
+    fun `community cards should be hidden at stage 0`() {
+        assertThat(round.getRevealedCommunityCards()).isEmpty()
     }
 
     @Test
-    fun `added Card is added`() {
-        val round = Round()
-        val card = Card(CardRank.FIVE, CardSuit.SPADES)
+    fun `community cards revealed correctly after each stage`() {
+        assertThat(round.getRevealedCommunityCards()).hasSize(0)
+        // Preflop to flop
+        round.doAction(Action.CALL) // Alice
+        round.doAction(Action.CALL) // Bob
+        round.doAction(Action.CALL) // Caroline
+        assertThat(round.getRevealedCommunityCards()).hasSize(3)
 
-        round.addCommunityCard(card)
-        val roundHasCard = round.communityCards.contains(card)
+        // Flop to turn
+        round.doAction(Action.CHECK)
+        round.doAction(Action.CHECK)
+//        round.doAction(Action.CHECK)
+        assertThat(round.getRevealedCommunityCards()).hasSize(4)
 
-        assertThat(roundHasCard).isTrue()
+        // Turn to river
+        round.doAction(Action.CHECK)
+        round.doAction(Action.CHECK)
+        round.doAction(Action.CHECK)
+        assertThat(round.getRevealedCommunityCards()).hasSize(5)
     }
 
     @Test
-    fun `Pot is 25 after adding 25`() {
-        val round = Round()
-
-        round.addToPot(25)
-        val pot = round.pot
-
-        assertThat(pot).isEqualTo(25)
+    fun `player cannot raise with insufficient funds`() {
+        players[0].money = 1
+        assertThatThrownBy {
+            round.doAction(Action.RAISE, 100)
+        }.isInstanceOf(NotEnoughMoneyException::class.java)
+            .hasMessageContaining("wants to raise")
     }
 
     @Test
-    fun `round state is correctly converted and restored`() {
-        val original = Round()
-        original.addToPot(50)
-        original.nextStage()
+    fun `player cannot raise with amount not greater than current bet`() {
+        round.doAction(Action.RAISE, 20) // Alice raises
+        assertThatThrownBy {
+            round.doAction(Action.RAISE, 5) // Bob tries invalid raise
+        }.isInstanceOf(NotEnoughToRaiseException::class.java)
+            .hasMessageContaining("not enough")
+    }
 
-        val state = original.toState()
+    @Test
+    fun `player cannot check if current bet is not matched`() {
+        assertThatThrownBy {
+            round.doAction(Action.CHECK)
+        }.isInstanceOf(CanNotCheckException::class.java)
+            .hasMessageContaining("can not check")
+    }
 
-        val copy = Round()
-        copy.fromState(state)
+    @Test
+    fun `folding skips player and marks them folded`() {
+        val initial = round.currentPlayer.name
+        round.doAction(Action.FOLD)
+        assertThat(round.players[0].hasFolded).isTrue()
+        assertThat(round.currentPlayer.name).isEqualTo("Bob")
+    }
 
+    @Test
+    fun `raise updates current bet and last raise position`() {
+        round.doAction(Action.RAISE, 20)
+        assertThat(round.currentBet).isEqualTo(20)
+        assertThat(round.players[0].money).isEqualTo(980)
+    }
 
-        assertThat(copy.pot).isEqualTo(50)
+    @Test
+    fun `round ends when only one player remains`() {
+        round.doAction(Action.FOLD) // Alice
+        round.doAction(Action.FOLD) // Bob
 
+        assertThat(round.isHandComplete).isTrue()
+        assertThat(round.lastWinnerAnnouncement).contains("Caroline")
+    }
 
-        assertThat(copy.stage).isEqualTo(1)
+    @Test
+    fun `players get winnings at showdown`() {
+        round.doAction(Action.CALL)
+        round.doAction(Action.CALL)
+        round.doAction(Action.CALL)
 
+        repeat(2) {
+            round.doAction(Action.CHECK)
+            round.doAction(Action.CHECK)
+            round.doAction(Action.CHECK)
+        }
 
-        assertThat(copy.communityCards.size).isEqualTo(5)
-        assertThat(copy.getRevealedCommunityCards().size).isEqualTo(3)
+        assertThat(round.isHandComplete).isTrue()
+        assertThat(round.pot).isEqualTo(0)
+        assertThat(players.sumOf { it.money }).isEqualTo(3000)
+    }
+
+    @Test
+    fun `player cannot tigger an action, after the hand end`() {
+        round.doAction(Action.CALL)
+        round.doAction(Action.CALL)
+        round.doAction(Action.CALL)
+
+        repeat(2) {
+            round.doAction(Action.CHECK)
+            round.doAction(Action.CHECK)
+            round.doAction(Action.CHECK)
+        }
+        assertThatThrownBy {
+            round.doAction(Action.CHECK)
+        }.isInstanceOf(HandIsCompleteException::class.java)
+            .hasMessageContaining("Hand is already complete")
+    }
+
+    @Test
+    fun `winner gets remainder of split pot`() {
+        round.doAction(Action.CALL)
+        round.doAction(Action.CALL)
+        round.doAction(Action.CALL)
+
+        repeat(2) {
+            round.doAction(Action.CHECK)
+            round.doAction(Action.CHECK)
+            round.doAction(Action.CHECK)
+        }
+
+        val totalMoney = players.sumOf { it.money }
+        assertThat(totalMoney).isEqualTo(3000)
+    }
+
+    @Test
+    fun `toState and fromState preserve state`() {
+        val state = round.toState()
+
+        val restoredRound = Round(players)
+        restoredRound.fromState(state)
+
+        assertThat(restoredRound.stage).isEqualTo(round.stage)
+        assertThat(restoredRound.pot).isEqualTo(round.pot)
+        assertThat(restoredRound.getRevealedCommunityCards())
+            .containsExactlyElementsOf(round.getRevealedCommunityCards())
     }
 }


### PR DESCRIPTION
Moves game logic into round(called Hand in poker). 
A round only has one public method which lets the active player trigger an action, like CALL, RAISE etc.

After a round is complete a new one as to be created.

Removed conformance to StateSerialisable for now.

## Testing
All added functions come with a 100% test coverage.