### PR TITLE
fixes and cleanup + tests

### DIFF
--- a/src/main/kotlin/PokerExceptions.kt
+++ b/src/main/kotlin/PokerExceptions.kt
@@ -1,0 +1,30 @@
+package hwr.oop.group1.poker
+
+class NotEnoughMoneyException (
+    player: Player,
+    amount: Int
+): RuntimeException(
+    "player $player wants to raise $amount but only has ${player.money}"
+)
+
+class CanNotCheckException (
+    player: Player
+): RuntimeException(
+    "player $player can not check"
+)
+
+class NotEnoughToRaiseException (
+    player: Player,
+    amount: Int
+): RuntimeException(
+    "player $player can not raise, because $amount is not enough"
+)
+
+class HandIsCompleteException: RuntimeException(
+    "The Hand is already complete, to play again start a new round."
+)
+
+class RoundStartedException : RuntimeException(
+    "The Round has already started"
+)
+

--- a/src/main/kotlin/hwr/oop/group1/poker/Deck.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/Deck.kt
@@ -1,15 +1,19 @@
 package hwr.oop.group1.poker
 
-class Deck {
-    private val cards = mutableListOf<Card>()
+class Deck (
+    private val cards: MutableList<Card> = mutableListOf()
+){
+
 
     init {
-        for(suit in CardSuit.entries){
-            for (rank in CardRank.entries){
-                cards += Card(rank, suit)
+        if(cards.isEmpty()){
+            for(suit in CardSuit.entries){
+                for (rank in CardRank.entries){
+                    cards += Card(rank, suit)
+                }
             }
+            cards.shuffle()
         }
-        cards.shuffle()
     }
 
     fun draw(): Card? = cards.removeFirstOrNull()

--- a/src/main/kotlin/hwr/oop/group1/poker/Game.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/Game.kt
@@ -7,7 +7,7 @@ class Game {
     var round: Round? = null
         private set
 
-    var players = emptyList<Player>().toMutableList()
+    var players = mutableListOf<Player>()
         private set
 
     var smallBlindAmount = 10
@@ -16,8 +16,7 @@ class Game {
     var bigBlindAmount = 20
         private set
 
-    // TODO: Increment after a round ended
-    private var dealerPosition: Int = -1
+    private var dealerPosition: Int = 0
 
     fun setSmallBlind(amount: Int) {
         require(amount > 0) { "Small blind must be greater than 0" }
@@ -37,12 +36,11 @@ class Game {
     }
 
     fun addPlayer(player: Player) {
-        // TODO: Exception if the current round isn't over
+        if (round != null && !round!!.isHandComplete) throw RoundStartedException()
         players += player
     }
 
     fun newRound() {
-        dealerPosition = (dealerPosition + 1) % players.size
         players.map {
             it.resetFold()
             it.resetCurrentBet()
@@ -53,5 +51,7 @@ class Game {
             bigBlindAmount,
             dealerPosition,
         )
+        round!!.setup()
+        dealerPosition = (dealerPosition + 1) % players.size
     }
 }

--- a/src/main/kotlin/hwr/oop/group1/poker/HandRank.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/HandRank.kt
@@ -13,8 +13,8 @@ data class HandRank(
     }
 }
 
-fun <T> List<T>.combinations(k: Int): List<List<T>> {
-    fun combine(start: Int, curr: List<T>): List<List<T>> {
+fun List<Card>.combinations(k: Int): List<List<Card>> {
+    fun combine(start: Int, curr: List<Card>): List<List<Card>> {
         if (curr.size == k) return listOf(curr)
         if (start >= this.size) return emptyList()
         return combine(start + 1, curr + this[start]) + combine(start + 1, curr)

--- a/src/main/kotlin/hwr/oop/group1/poker/Player.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/Player.kt
@@ -1,7 +1,6 @@
 package hwr.oop.group1.poker
 
 import kotlinx.serialization.Serializable
-import kotlin.math.max
 import kotlin.math.min
 
 @Serializable
@@ -15,6 +14,8 @@ class Player(
         private set
     var currentBet = 0
         private set
+    var hasChecked = false
+        private set
 
     fun addCard(card: Card) {
         hand.add(card)
@@ -27,12 +28,13 @@ class Player(
     fun betMoney(money: Int): Int {
         val amount = min(money, this.money)
         this.money -= amount
-        currentBet = max(currentBet, amount)
+        currentBet += amount
         return amount
     }
 
     fun resetCurrentBet() {
         currentBet = 0
+        hasChecked = false
     }
 
     fun fold() {
@@ -42,6 +44,14 @@ class Player(
 
     fun resetFold() {
         hasFolded = false
+    }
+
+    fun isActive(): Boolean {
+        return !hasFolded || money == 0
+    }
+
+    fun setChecked() {
+        hasChecked = true
     }
 
     /**

--- a/src/main/kotlin/hwr/oop/group1/poker/persistence/GamePersistence.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/persistence/GamePersistence.kt
@@ -1,31 +1,8 @@
 package hwr.oop.group1.poker.persistence
 
 import hwr.oop.group1.poker.Game
-import kotlinx.serialization.json.Json
-import java.io.File
 
 interface GamePersistence {
     fun saveGame(game: Game)
     fun loadGame(): Game?
-}
-
-class JSONGamePersistence(private val file: File) : GamePersistence {
-    private val json = Json {
-        prettyPrint = true
-        ignoreUnknownKeys = true
-    }
-
-    override fun saveGame(game: Game) {
-        file.writeText(json.encodeToString(game))
-    }
-
-    override fun loadGame(): Game? {
-        if (!file.exists()) return null
-        return try {
-            json.decodeFromString<Game>(file.readText())
-        } catch (e: Exception) {
-            println("Error loading state: ${e.message}")
-            null
-        }
-    }
 }

--- a/src/main/kotlin/hwr/oop/group1/poker/persistence/JSONGamePersistence.kt
+++ b/src/main/kotlin/hwr/oop/group1/poker/persistence/JSONGamePersistence.kt
@@ -1,0 +1,26 @@
+package hwr.oop.group1.poker.persistence
+
+import hwr.oop.group1.poker.Game
+import kotlinx.serialization.json.Json
+import java.io.File
+
+class JSONGamePersistence(private val file: File) : GamePersistence {
+    private val json = Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
+    }
+
+    override fun saveGame(game: Game) {
+        file.writeText(json.encodeToString(game))
+    }
+
+    override fun loadGame(): Game? {
+        if (!file.exists()) return null
+        return try {
+            json.decodeFromString<Game>(file.readText())
+        } catch (e: Exception) {
+            println("Error loading state: ${e.message}")
+            null
+        }
+    }
+}

--- a/src/test/kotlin/hwr/oop/group1/poker/CardTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/CardTest.kt
@@ -1,7 +1,9 @@
 package hwr.oop.group1.poker
 
 import io.kotest.core.spec.style.AnnotationSpec
+import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
+import java.io.File
 
 class CardTest: AnnotationSpec() {
 
@@ -14,5 +16,21 @@ class CardTest: AnnotationSpec() {
 
         assertThat(rank).isEqualTo(CardRank.KING)
         assertThat(suit).isEqualTo(CardSuit.DIAMONDS)
+    }
+
+    @Test
+    fun `card can be saved and loaded`() {
+        val json = Json
+        val file = File("test_game.json")
+        val expectedCard = Card(CardRank.KING, CardSuit.DIAMONDS)
+
+        file.writeText(json.encodeToString(expectedCard))
+
+        val loadedCard = json.decodeFromString<Card>(file.readText())
+
+        file.delete()
+
+        assertThat(loadedCard).isNotNull()
+        assertThat(loadedCard).usingRecursiveComparison().isEqualTo(expectedCard)
     }
 }

--- a/src/test/kotlin/hwr/oop/group1/poker/GameTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/GameTest.kt
@@ -34,6 +34,19 @@ class GameTest: AnnotationSpec() {
     }
 
     @Test
+    fun `Player can not be added if round started`() {
+        val game = Game()
+        val player = Player("Max", 1000)
+
+        game.addPlayer(Player("Alice", 1000))
+        game.addPlayer(Player("Bob", 1000))
+        game.newRound()
+        assertThatThrownBy {
+            game.addPlayer(player)
+        }.hasMessageContaining("The Round has already started")
+    }
+
+    @Test
     fun `Set small and big blind sets it correctly`() {
         val game = Game()
 

--- a/src/test/kotlin/hwr/oop/group1/poker/HandRankTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/HandRankTest.kt
@@ -187,29 +187,4 @@ class HandRankTest: AnnotationSpec() {
 
         assertThat(hand1.compareTo(hand2)).isEqualTo(0)
     }
-
-    @Test
-    fun `get all combinations`() {
-        val cards = listOf(1, 2, 3)
-        val combinations = cards.combinations(2)
-
-        assertThat(combinations).isEqualTo(listOf(listOf(1, 2), listOf(1, 3), listOf(2, 3)))
-    }
-
-    @Test
-    fun `combinations returns correct number of combos`() {
-        val input = listOf(1, 2, 3, 4, 5, 6, 7)
-        val result = input.combinations(5)
-
-        assertThat(21).isEqualTo(result.size) // C(7,5) = 21
-        assertThat(result.all { it.size == 5 }).isTrue()
-    }
-
-    @Test
-    fun `combinations edge case empty list`() {
-        val input = emptyList<Int>()
-        val result = input.combinations(3)
-
-        assertThat(result.isEmpty()).isTrue()
-    }
 }

--- a/src/test/kotlin/hwr/oop/group1/poker/PlayerTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/PlayerTest.kt
@@ -1,7 +1,9 @@
 package hwr.oop.group1.poker
 
 import io.kotest.core.spec.style.AnnotationSpec
+import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
+import java.io.File
 
 class PlayerTest: AnnotationSpec() {
 
@@ -35,13 +37,10 @@ class PlayerTest: AnnotationSpec() {
     }
     @Test
     fun `fold sets hasFolded to true `() {
-
         val player = Player("Saruman", 50)
-        assertThat(player.hasFolded).isFalse()  // vorab
-
+        assertThat(player.hasFolded).isFalse()
 
         player.fold()
-
 
         assertThat(player.hasFolded).isTrue()
     }
@@ -65,6 +64,22 @@ class PlayerTest: AnnotationSpec() {
         assertThat(player.hasFolded).isTrue()
         player.resetFold()
         assertThat(player.hasFolded).isFalse()
+    }
+
+    @Test
+    fun `player can be saved and loaded`() {
+        val json = Json
+        val file = File("test_game.json")
+        val expectedPlayer = Player("Max", 1000)
+
+        file.writeText(json.encodeToString(expectedPlayer))
+
+        val loadedPlayer = json.decodeFromString<Player>(file.readText())
+
+        file.delete()
+
+        assertThat(loadedPlayer).isNotNull()
+        assertThat(loadedPlayer).usingRecursiveComparison().isEqualTo(expectedPlayer)
     }
 }
 

--- a/src/test/kotlin/hwr/oop/group1/poker/RoundTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/RoundTest.kt
@@ -1,12 +1,14 @@
 package hwr.oop.group1.poker
 
 import io.kotest.core.spec.style.AnnotationSpec
+import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import java.io.File
 
 class RoundTest : AnnotationSpec() {
-    lateinit var round: Round
-    lateinit var players: List<Player>
+    private lateinit var round: Round
+    private lateinit var players: List<Player>
 
     @BeforeEach
     fun setUp() {
@@ -16,6 +18,7 @@ class RoundTest : AnnotationSpec() {
             Player("Caroline", 1000)
         )
         round = Round(players, 5, 10)
+        round.setup()
     }
 
     @Test
@@ -36,6 +39,18 @@ class RoundTest : AnnotationSpec() {
     }
 
     @Test
+    fun `currentPlayer is dealer when only 2 players`() {
+        players = listOf(
+            Player("Alice", 1000),
+            Player("Bob", 1000),
+        )
+        round = Round(players, 5, 10)
+        round.setup()
+
+        assertThat(round.currentPlayer.name).isEqualTo("Alice")
+    }
+
+    @Test
     fun `community cards should be hidden at stage 0`() {
         assertThat(round.getRevealedCommunityCards()).isEmpty()
     }
@@ -46,13 +61,13 @@ class RoundTest : AnnotationSpec() {
         // Preflop to flop
         round.doAction(Action.CALL) // Alice
         round.doAction(Action.CALL) // Bob
-        round.doAction(Action.CALL) // Caroline
+        round.doAction(Action.CHECK) // Caroline
         assertThat(round.getRevealedCommunityCards()).hasSize(3)
 
         // Flop to turn
         round.doAction(Action.CHECK)
         round.doAction(Action.CHECK)
-//        round.doAction(Action.CHECK)
+        round.doAction(Action.CHECK)
         assertThat(round.getRevealedCommunityCards()).hasSize(4)
 
         // Turn to river
@@ -116,9 +131,9 @@ class RoundTest : AnnotationSpec() {
     fun `players get winnings at showdown`() {
         round.doAction(Action.CALL)
         round.doAction(Action.CALL)
-        round.doAction(Action.CALL)
+        round.doAction(Action.CHECK)
 
-        repeat(2) {
+        repeat(3) {
             round.doAction(Action.CHECK)
             round.doAction(Action.CHECK)
             round.doAction(Action.CHECK)
@@ -130,12 +145,12 @@ class RoundTest : AnnotationSpec() {
     }
 
     @Test
-    fun `player cannot tigger an action, after the hand end`() {
+    fun `player cannot trigger an action, after the hand end`() {
         round.doAction(Action.CALL)
         round.doAction(Action.CALL)
-        round.doAction(Action.CALL)
+        round.doAction(Action.CHECK)
 
-        repeat(2) {
+        repeat(3) {
             round.doAction(Action.CHECK)
             round.doAction(Action.CHECK)
             round.doAction(Action.CHECK)
@@ -148,17 +163,63 @@ class RoundTest : AnnotationSpec() {
 
     @Test
     fun `winner gets remainder of split pot`() {
-        round.doAction(Action.CALL)
-        round.doAction(Action.CALL)
-        round.doAction(Action.CALL)
+        val deck = Deck(
+            mutableListOf(
+                Card(CardRank.ACE, CardSuit.HEARTS),
+                Card(CardRank.ACE, CardSuit.HEARTS),
 
-        repeat(2) {
+                Card(CardRank.ACE, CardSuit.HEARTS),
+                Card(CardRank.ACE, CardSuit.HEARTS),
+
+                Card(CardRank.TWO, CardSuit.HEARTS),
+                Card(CardRank.TWO, CardSuit.HEARTS),
+
+                Card(CardRank.THREE, CardSuit.HEARTS),
+                Card(CardRank.FIVE, CardSuit.HEARTS),
+                Card(CardRank.ACE, CardSuit.HEARTS),
+                Card(CardRank.ACE, CardSuit.HEARTS),
+                Card(CardRank.ACE, CardSuit.HEARTS),
+
+                Card(CardRank.ACE, CardSuit.HEARTS),
+                Card(CardRank.ACE, CardSuit.HEARTS),
+            )
+        )
+        players = listOf(
+            Player("Alice", 1000),
+            Player("Bob", 1000),
+            Player("Caroline", 1000)
+        )
+        round = Round(players, 2, 5, setupDeck = deck)
+        round.setup()
+
+        round.doAction(Action.CALL)
+        round.doAction(Action.CALL)
+        round.doAction(Action.CHECK)
+
+        repeat(3) {
             round.doAction(Action.CHECK)
             round.doAction(Action.CHECK)
             round.doAction(Action.CHECK)
         }
 
-        val totalMoney = players.sumOf { it.money }
-        assertThat(totalMoney).isEqualTo(3000)
+        assertThat(players[0].money).isEqualTo(995 + 8)
+        assertThat(players[1].money).isEqualTo(995 + 7)
+        assertThat(players[2].money).isEqualTo(995)
+    }
+
+    @Test
+    fun `round can be saved and loaded`() {
+        val json = Json
+        val file = File("test_game.json")
+        val expectedRound = round
+
+        file.writeText(json.encodeToString(expectedRound))
+
+        val loadedRound = json.decodeFromString<Round>(file.readText())
+
+        file.delete()
+
+        assertThat(loadedRound).isNotNull()
+        assertThat(loadedRound).usingRecursiveComparison().isEqualTo(expectedRound)
     }
 }

--- a/src/test/kotlin/hwr/oop/group1/poker/persitence/GamePersistenceTest.kt
+++ b/src/test/kotlin/hwr/oop/group1/poker/persitence/GamePersistenceTest.kt
@@ -1,5 +1,6 @@
 package hwr.oop.group1.poker.persitence
 
+import hwr.oop.group1.poker.Action
 import hwr.oop.group1.poker.Game
 import hwr.oop.group1.poker.Player
 import hwr.oop.group1.poker.persistence.GamePersistence
@@ -49,6 +50,27 @@ class GamePersistenceTest: AnnotationSpec() {
         val player1 = Player("Max", 1000)
 
         expectedGame.addPlayer(player1)
+        adapter.saveGame(expectedGame)
+
+        val loadedGame = adapter.loadGame()
+
+        assertThat(loadedGame).isNotNull()
+        assertThat(loadedGame).usingRecursiveComparison().isEqualTo(expectedGame)
+    }
+
+    @Test
+    fun `loaded Game should not perform init`() {
+        val expectedGame = Game()
+        val player1 = Player("Max", 1000)
+        val player2 = Player("Ben", 1000)
+        val player3 = Player("Alice", 1000)
+
+        expectedGame.addPlayer(player1)
+        expectedGame.addPlayer(player2)
+        expectedGame.addPlayer(player3)
+        expectedGame.newRound()
+        expectedGame.round!!.doAction(Action.CALL)
+
         adapter.saveGame(expectedGame)
 
         val loadedGame = adapter.loadGame()


### PR DESCRIPTION
# Fixes
- bettingRoundComplete now checks if everyone has current bet or if everyone has checked (avoids compications with folds)
-  Exception when player gets added when round already started -> closes #27 
- Round has setup instead of init to because it was called again be the persistence  

# Cleanup
- moved Exceptions + JSONGamePersistence to own file
- removed unnecessary attributes from Roun 
- specified List<T>.combinations to List<Card>.combinations
- moved finding the next active player to own method

# Tests 
- Deck can be given to Round for better testability 
- 100% line coverage (branch and mutation coverage need to be checked)